### PR TITLE
Remove the git versions of mono since they are not being built.

### DIFF
--- a/recipes-mono/mono/mono-native_git.bb
+++ b/recipes-mono/mono/mono-native_git.bb
@@ -1,8 +1,0 @@
-require mono-git.inc
-require ${PN}-base.inc
-
-do_compile() {
-    make get-monolite-latest
-    make EXTERNAL_MCS="${S}/mcs/class/lib/monolite/basic.exe" EXTERNAL_RUNTIME="${S}/foo/bar/mono"
-}
-

--- a/recipes-mono/mono/mono_git.bb
+++ b/recipes-mono/mono/mono_git.bb
@@ -1,2 +1,0 @@
-require mono-git.inc
-require ${PN}-base.inc


### PR DESCRIPTION
Cherry-picked to 20.6 from e1aa1f8ea377875b51c38fb4da26ec41a0443664

Signed-off-by: James Minor <james.minor@ni.com>