### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -8,7 +8,7 @@ RDEPENDS_${PN} += " perl gtk+3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8754deb904d22254188cb67189b87f19"
 
 SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
-SRC_URI = "git://github.com/mono/gtk-sharp.git;branch=master \
+SRC_URI = "git://github.com/mono/gtk-sharp.git;branch=master;protocol=https \
            file://0001-fixup-gmcs-to-mcs.patch"
 
 S = "${WORKDIR}/git"

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -11,7 +11,7 @@ DEPENDS = "mono"
 SRCREV = "64a45d96f39d4714ec85adf0fe04b68ec7273ae1"
 SRCBRANCH = "master"
 
-SRC_URI = "git://github.com/mono/mono-addins.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/mono/mono-addins.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -11,7 +11,7 @@ DEPENDS = "gtk-sharp"
 SRCREV = "64a45d96f39d4714ec85adf0fe04b68ec7273ae1"
 SRCBRANCH = "master"
 
-SRC_URI = "git://github.com/mono/mono-addins.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/mono/mono-addins.git;branch=${SRCBRANCH};protocol=https \
 	   file://0001-configure-mcs.patch"
 
 S = "${WORKDIR}/git"

--- a/recipes-mono/mono-upnp/mono-upnp.inc
+++ b/recipes-mono/mono-upnp/mono-upnp.inc
@@ -13,7 +13,7 @@ SRCBRANCH = "master"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-SRC_URI = "git://github.com/mono/mono-upnp.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/mono/mono-upnp.git;branch=${SRCBRANCH};protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -1,7 +1,7 @@
 require mono-xsp-3.x.inc
 
 SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
-SRC_URI = "git://github.com/mono/xsp.git \
+SRC_URI = "git://github.com/mono/xsp.git;protocol=https \
 	  "
 
 S = "${WORKDIR}/git"

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=80862f3fd0e11a5fa0318070c54461ce"
 SRCBRANCH = "master"
 SRCREV = "${AUTOREV}"
 
-SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
+SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH};protocol=https \
            file://dllmap-config.in.diff \
 	   file://0002-prevent-threadpool-exception5-test-hanging.patch \
 "

--- a/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
+++ b/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE.TXT;md5=9fc642ff452b28d62ab19b
 
 COMPATIBLE_HOST ?= "(i.86|x86_64|arm|aarch64).*-linux"
 
-SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1 \
+SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1;protocol=https \
            file://0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch;patchdir=${WORKDIR}/git \
            file://0002-Remove-broken-objcopy-detection-STRIP_SYMBOLS-is-uns.patch;patchdir=${WORKDIR}/git \
            "

--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -14,7 +14,7 @@ inherit mono
 
 SRCREV = "94d0c55bc96f297618d50cc32167ddba9fee30b0"
 
-SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main \
+SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protocol=https \
            file://mono-msbuild-dotnetbits-case.patch \
            file://mono-msbuild-license-case.patch \
            file://mono-msbuild-no-hostfxr.patch \

--- a/recipes-mono/taglib-sharp/taglib-sharp.inc
+++ b/recipes-mono/taglib-sharp/taglib-sharp.inc
@@ -8,7 +8,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343"
 DEPENDS = "mono"
 
-SRC_URI = "git://github.com/mono/taglib-sharp.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/mono/taglib-sharp.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos